### PR TITLE
Return errors inline in the array in batch operations.

### DIFF
--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -813,7 +813,7 @@ kafkatcl_message_to_tcl_list (Tcl_Interp *interp, rd_kafka_message_t *rdm) {
 void
 kafkatcl_unset_error_elements (Tcl_Interp *interp, char *arrayName) {
 	Tcl_UnsetVar2 (interp, arrayName, "error", 0);
-	Tcl_UnsetVar2 (interp, arrayName, "response", 0);
+	Tcl_UnsetVar2 (interp, arrayName, "code", 0);
 	Tcl_UnsetVar2 (interp, arrayName, "message", 0);
 }
 


### PR DESCRIPTION
Errors from batch operations abort the batch, which loses unprocessed messages. This patch returns errors inline in batch operations, with the array elements "error", "code", and "message".