### PR TITLE
Tcl event cleanup

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -18,7 +18,7 @@ dnl	to configure the system for the local environment.
 # so you can encode the package version directly into the source files.
 #-----------------------------------------------------------------------
 
-AC_INIT([kafka], [2.3.0])
+AC_INIT([kafka], [2.4.1])
 
 #-----
 # Version with patch stripped

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -4271,7 +4271,7 @@ kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int 
 			}
 
 			if(kh->inCallback) {
-				Tcl_SetObjResult (interp, Tcl_NewStringObj ("Can not delete Subecriber from inside subscriber callback", -1));
+				Tcl_SetObjResult (interp, Tcl_NewStringObj ("Can not delete Subscriber from inside subscriber callback", -1));
 				return TCL_ERROR;
 			}
 

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -28,6 +28,13 @@ kafkatcl_consume_stop_all_partitions (kafkatcl_topicClientData *kt);
 int
 kafkatcl_handleObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[]);
 
+void
+kafkatcl_EventSetupProc (ClientData clientData, int flags);
+void
+kafkatcl_EventCheckProc (ClientData clientData, int flags);
+void
+kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags);
+
 // DEBUG
 #ifdef DEBUGPRINTF
 void kafkatcl_dump_topic_partition_list(rd_kafka_topic_partition_list_t *topics)
@@ -157,6 +164,9 @@ kafkatcl_handleObjectDelete (ClientData clientData)
 
 	rd_kafka_topic_conf_destroy (kh->topicConf);
 
+	// Stop passing this to Tcl event handlers
+        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_EventCheckProc, (ClientData) kh);
+
     ckfree((char *)clientData);
 }
 
@@ -235,6 +245,9 @@ kafkatcl_subscriberObjectDelete (ClientData clientData)
 	if (kh->topicConf != NULL) {
 		rd_kafka_topic_conf_destroy (kh->topicConf);
 	}
+
+	// Stop passing Tcl events to this object
+        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_SubscriberEventCheckProc, (ClientData) kh);
 
 	// clear the kafka handle magic number; this will help us catch
 	// attempted reuse of the structure after freeing
@@ -1117,6 +1130,8 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 		Tcl_AppendResult (interp, " while converting callback argument", NULL);
 		return TCL_ERROR;
 	}
+fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
+		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
 
 	evalObjc = callbackListObjc + 1;
 	evalObjv = (Tcl_Obj **)ckalloc (sizeof (Tcl_Obj *) * evalObjc);
@@ -1188,6 +1203,7 @@ kafkatcl_EventSetupProc (ClientData clientData, int flags) {
 void
 kafkatcl_EventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
+fprintf(stderr, "kafkatcl_EventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
 
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
@@ -3743,6 +3759,7 @@ kafkatcl_set_subscriber_callback(Tcl_Interp *interp, kafkatcl_handleClientData *
 void
 kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
+fprintf(stderr, "kafkatcl_SubscriberEventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 	rd_kafka_t *rk = kh->rk;
 	rd_kafka_message_t *message;

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -1128,6 +1128,9 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 	Tcl_Obj **callbackListObjv;
 	int tclReturnCode;
 
+fprintf(stderr, "-->kafkatcl_invoke_callback_with_argument(interp, callbackObj='%s', argumentObj='%s');\n",
+		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
+
 	int evalObjc;
 	Tcl_Obj **evalObjv;
 
@@ -1164,6 +1167,9 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 	}
 
 	ckfree ((char *)evalObjv);
+
+fprintf(stderr, "<--kafkatcl_invoke_callback_with_argument()\n");
+
 	return tclReturnCode;
 }
 
@@ -1236,6 +1242,7 @@ kafkatcl_logging_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_loggingEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
+fprintf(stderr, "-->kafkatcl_logging_eventProc\n");
 
 	kafkatcl_loggingEvent *evPtr = (kafkatcl_loggingEvent *)tevPtr;
 	Tcl_Interp *interp = evPtr->interp;
@@ -1276,6 +1283,7 @@ kafkatcl_logging_eventProc (Tcl_Event *tevPtr, int flags) {
 	kafkatcl_invoke_callback_with_argument (interp, kafkatcl_loggingCallbackObj, listObj);
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
+fprintf(stderr, "<--kafkatcl_logging_eventProc\n");
 	return 1;
 }
 
@@ -1299,6 +1307,7 @@ kafkatcl_stats_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_statsEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
+fprintf(stderr, "-->kafkatcl_stats_eventProc\n");
 
 	kafkatcl_statsEvent *evPtr = (kafkatcl_statsEvent *)tevPtr;
 	kafkatcl_objectClientData *ko = evPtr->ko;
@@ -1314,6 +1323,7 @@ kafkatcl_stats_eventProc (Tcl_Event *tevPtr, int flags) {
 	free (evPtr->json);
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
+fprintf(stderr, "<--kafkatcl_stats_eventProc\n");
 	return 1;
 }
 
@@ -1337,6 +1347,7 @@ kafkatcl_error_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_errorEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
+fprintf(stderr, "-->kafkatcl_error_eventProc;\n");
 
 	kafkatcl_errorEvent *evPtr = (kafkatcl_errorEvent *)tevPtr;
 	kafkatcl_objectClientData *ko = evPtr->ko;
@@ -1378,7 +1389,8 @@ kafkatcl_error_eventProc (Tcl_Event *tevPtr, int flags) {
 	kafkatcl_invoke_callback_with_argument (interp, ko->errorCallbackObj, listObj);
 
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
-	// it and don't want it removed from the queue
+// it and don't want it removed from the queue
+fprintf(stderr, "<--kafkatcl_error_eventProc;\n");
 	return 1;
 }
 
@@ -1499,6 +1511,7 @@ int kafkatcl_stats_callback (rd_kafka_t *rk, char  *json, size_t jsonLen, void *
  */
 int
 kafkatcl_delivery_report_eventProc (Tcl_Event *tevPtr, int flags) {
+fprintf(stderr, "-->kafkatcl_delivery_report_eventProc;\n");
 
 	// we got called with a Tcl_Event pointer but really it's a pointer to
 	// our kafkatcl_statsEvent structure that has the Tcl_Event and
@@ -1527,6 +1540,7 @@ kafkatcl_delivery_report_eventProc (Tcl_Event *tevPtr, int flags) {
 
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
+fprintf(stderr, "<--kafkatcl_delivery_report_eventProc;\n");
 	return 1;
 }
 
@@ -2556,6 +2570,7 @@ kafkatcl_check_consumer_callbacks (kafkatcl_objectClientData *ko) {
 int
 kafkatcl_topicConsumerObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_topicConsumerObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_topicClientData *kt = (kafkatcl_topicClientData *)cData;
 	rd_kafka_topic_t *rkt = kt->rkt;
@@ -2835,6 +2850,7 @@ kafkatcl_topicConsumerObjectObjCmd(ClientData cData, Tcl_Interp *interp, int obj
 int
 kafkatcl_topicProducerObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_topicProducerObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_topicClientData *kt = (kafkatcl_topicClientData *)cData;
 	rd_kafka_topic_t *rkt = kt->rkt;
@@ -3089,6 +3105,7 @@ kafkatcl_createTopicObjectCommand (kafkatcl_handleClientData *kh, char *cmdName,
 int
 kafkatcl_queueObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_queueObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_queueClientData *kq = (kafkatcl_queueClientData *)cData;
 	rd_kafka_queue_t *rkqu = kq->rkqu;
@@ -3317,6 +3334,7 @@ kafkatcl_add_brokers (kafkatcl_handleClientData *kh, Tcl_Obj *brokers) {
 int
 kafkatcl_handleObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_handleObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)cData;
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
@@ -3812,6 +3830,7 @@ fprintf(stderr, "<- kafkatcl_SubscriberEventCheckProc();\n");
 int
 kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_handleSubscriberObjectObjCmd\n");
 	int                        optIndex;
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)cData;
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
@@ -4507,6 +4526,7 @@ kafkatcl_createSubscriberObjectCommand (kafkatcl_objectClientData *ko, char *cmd
 int
 kafkatcl_kafkaObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_kafkaObjectObjCmd\n");
 	int         optIndex;
 	kafkatcl_objectClientData *ko = (kafkatcl_objectClientData *)cData;
 	int resultCode = TCL_OK;
@@ -4859,10 +4879,13 @@ kafkatcl_kafkaObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_O
 int
 kafkatcl_kafkaObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
+fprintf(stderr, "kafkatcl_kafkaObjCmd\n");
     kafkatcl_objectClientData *ko;
     int                 optIndex;
     char               *cmdName;
     int                 autoGeneratedName;
+
+fprintf(stderr, "kafkatcl_kafkaObjCmd\n");
 
     static CONST char *options[] = {
         "create",
@@ -4960,6 +4983,4 @@ kafkatcl_kafkaObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Ob
 }
 
 /* vim: set ts=4 sw=4 sts=4 noet : */
-
-
 

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -3834,6 +3834,7 @@ kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int 
 		"meta",
 		"info",
 		"delete",
+		"error",
 		NULL
 	};
 
@@ -3849,7 +3850,8 @@ kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int 
 		OPT_WATERMARKS,
 		OPT_META,
 		OPT_INFO,
-		OPT_DELETE
+		OPT_DELETE,
+		OPT_ERROR
 	};
 
 	/* basic validation of command line arguments */
@@ -4281,6 +4283,18 @@ kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int 
 			break;
 		}
 
+		case OPT_ERROR: {
+			if (objc != 4) {
+				Tcl_WrongNumArgs(interp, 2, objv, "errno reason");
+				return TCL_ERROR;
+			}
+
+			if (Tcl_GetIntFromObj (interp, objv[2], &errno) == TCL_ERROR) {
+				return TCL_ERROR;
+			}
+
+			kafkatcl_error_callback(rk, errno, Tcl_GetString(objv[3]), (void *)(kh->ko));
+		}
     }
     return resultCode;
 }

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -228,7 +228,7 @@ void
 kafkatcl_subscriberObjectDelete (ClientData clientData)
 {
     kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-#fprintf(stderr, "kafkatcl_subscriberObjectDelete(clientData = 0x%08lx);\n", (long)clientData);
+//fprintf(stderr, "kafkatcl_subscriberObjectDelete(clientData = 0x%08lx);\n", (long)clientData);
 
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
@@ -1131,7 +1131,7 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 		Tcl_AppendResult (interp, " while converting callback argument", NULL);
 		return TCL_ERROR;
 	}
-#fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
+//fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
 		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
 
 	evalObjc = callbackListObjc + 1;
@@ -1204,7 +1204,7 @@ kafkatcl_EventSetupProc (ClientData clientData, int flags) {
 void
 kafkatcl_EventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-#fprintf(stderr, "kafkatcl_EventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
+//fprintf(stderr, "kafkatcl_EventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
 
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
@@ -3760,7 +3760,7 @@ kafkatcl_set_subscriber_callback(Tcl_Interp *interp, kafkatcl_handleClientData *
 void
 kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-#fprintf(stderr, "kafkatcl_SubscriberEventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
+//fprintf(stderr, "kafkatcl_SubscriberEventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 	rd_kafka_t *rk = kh->rk;
 	rd_kafka_message_t *message;

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -165,7 +165,7 @@ kafkatcl_handleObjectDelete (ClientData clientData)
 	rd_kafka_topic_conf_destroy (kh->topicConf);
 
 	// Stop passing this to Tcl event handlers
-        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_EventCheckProc, (ClientData) kh);
+        //Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_EventCheckProc, (ClientData) kh);
 
     ckfree((char *)clientData);
 }
@@ -237,7 +237,7 @@ kafkatcl_subscriberObjectDelete (ClientData clientData)
 	kh->subscriberCallback = NULL;
 
 	// Stop passing Tcl events to this object
-        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_SubscriberEventCheckProc, (ClientData) kh);
+        //Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_SubscriberEventCheckProc, (ClientData) kh);
 
 	// Clen up topic and metadata before destroying subscriber
 	// (see https://github.com/edenhill/librdkafka/wiki/Proper-termination-sequence )

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -228,26 +228,27 @@ void
 kafkatcl_subscriberObjectDelete (ClientData clientData)
 {
     kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
+#fprintf(stderr, "kafkatcl_subscriberObjectDelete(clientData = 0x%08lx);\n", (long)clientData);
 
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
-	// TODO: if there's a queue out, call rd_kafka_queue_destroy() on it
+	// Stop passing Tcl events to this object
+        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_SubscriberEventCheckProc, (ClientData) kh);
 
-	rd_kafka_consumer_close(kh->rk);
-
-	rd_kafka_destroy (kh->rk);
+	if (kh->topicConf != NULL) {
+		rd_kafka_topic_conf_destroy (kh->topicConf);
+	}
 
 	// destroy metadata if it exists
 	if (kh->metadata != NULL) {
 		rd_kafka_metadata_destroy (kh->metadata);
 	}
 
-	if (kh->topicConf != NULL) {
-		rd_kafka_topic_conf_destroy (kh->topicConf);
-	}
+	// TODO: if there's a queue out, call rd_kafka_queue_destroy() on it
 
-	// Stop passing Tcl events to this object
-        Tcl_DeleteEventSource (kafkatcl_EventSetupProc, kafkatcl_SubscriberEventCheckProc, (ClientData) kh);
+	rd_kafka_consumer_close(kh->rk);
+
+	rd_kafka_destroy (kh->rk);
 
 	// clear the kafka handle magic number; this will help us catch
 	// attempted reuse of the structure after freeing
@@ -1130,7 +1131,7 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 		Tcl_AppendResult (interp, " while converting callback argument", NULL);
 		return TCL_ERROR;
 	}
-fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
+#fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
 		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
 
 	evalObjc = callbackListObjc + 1;
@@ -1203,7 +1204,7 @@ kafkatcl_EventSetupProc (ClientData clientData, int flags) {
 void
 kafkatcl_EventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-fprintf(stderr, "kafkatcl_EventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
+#fprintf(stderr, "kafkatcl_EventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
 
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
@@ -3759,7 +3760,7 @@ kafkatcl_set_subscriber_callback(Tcl_Interp *interp, kafkatcl_handleClientData *
 void
 kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-fprintf(stderr, "kafkatcl_SubscriberEventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
+#fprintf(stderr, "kafkatcl_SubscriberEventCheckProc (ClientData clientData=0x%08lx, int flags=%d);\n", (long)clientData, flags);
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 	rd_kafka_t *rk = kh->rk;
 	rd_kafka_message_t *message;

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -1132,7 +1132,7 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 		return TCL_ERROR;
 	}
 //fprintf(stderr, "kafkatcl_invoke_callback_with_argument(interp, callbackObj={%s}, argumentObj={%s});\n",
-		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
+//		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
 
 	evalObjc = callbackListObjc + 1;
 	evalObjv = (Tcl_Obj **)ckalloc (sizeof (Tcl_Obj *) * evalObjc);

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -1524,7 +1524,9 @@ kafkatcl_delivery_report_eventProc (Tcl_Event *tevPtr, int flags) {
 	// even if this fails we still want the event taken off the queue
 	// this function will do the background error thing if there is a tcl
 	// error running the callback
-	kafkatcl_invoke_callback_with_argument (interp, ko->deliveryReportCallbackObj, listObj);
+	if(listObj) {
+		kafkatcl_invoke_callback_with_argument (interp, ko->deliveryReportCallbackObj, listObj);
+	}
 
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
@@ -1886,7 +1888,7 @@ kafkatcl_consume_callback_eventProc (Tcl_Event *tevPtr, int flags) {
 	kafkatcl_consumeCallbackEvent *evPtr = (kafkatcl_consumeCallbackEvent *)tevPtr;
 	kafkatcl_runningConsumer *krc = evPtr->krc;
 
-    assert (krc->kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
+	assert (krc->kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
 	Tcl_Interp *interp = krc->kh->interp;
 
@@ -1933,7 +1935,7 @@ kafkatcl_consume_callback_queue_eventProc (Tcl_Event *tevPtr, int flags) {
 	kafkatcl_consumeCallbackEvent *evPtr = (kafkatcl_consumeCallbackEvent *)tevPtr;
 	kafkatcl_runningConsumer *krc = evPtr->krc;
 
-    assert (krc->kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
+	assert (krc->kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 
 	Tcl_Interp *interp = krc->kh->interp;
 

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -3788,7 +3788,6 @@ kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags) {
 		rd_kafka_message_destroy(message);
 
 		if(msgList) {
-			fprintf(stderr, "\tInvoking callback '%s' '%s'\n", Tcl_GetString(cb), Tcl_GetString(msgList));
 			// Note - this increments and decrements the refcount on msgList.
 			kafkatcl_invoke_callback_with_argument (interp, cb, msgList);
 		}

--- a/generic/kafkatcl.c
+++ b/generic/kafkatcl.c
@@ -1128,9 +1128,6 @@ kafkatcl_invoke_callback_with_argument (Tcl_Interp *interp, Tcl_Obj *callbackObj
 	Tcl_Obj **callbackListObjv;
 	int tclReturnCode;
 
-fprintf(stderr, "-->kafkatcl_invoke_callback_with_argument(interp, callbackObj='%s', argumentObj='%s');\n",
-		Tcl_GetString(callbackObj), Tcl_GetString(argumentObj));
-
 	int evalObjc;
 	Tcl_Obj **evalObjv;
 
@@ -1167,8 +1164,6 @@ fprintf(stderr, "-->kafkatcl_invoke_callback_with_argument(interp, callbackObj='
 	}
 
 	ckfree ((char *)evalObjv);
-
-fprintf(stderr, "<--kafkatcl_invoke_callback_with_argument()\n");
 
 	return tclReturnCode;
 }
@@ -1242,7 +1237,6 @@ kafkatcl_logging_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_loggingEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
-fprintf(stderr, "-->kafkatcl_logging_eventProc\n");
 
 	kafkatcl_loggingEvent *evPtr = (kafkatcl_loggingEvent *)tevPtr;
 	Tcl_Interp *interp = evPtr->interp;
@@ -1283,7 +1277,6 @@ fprintf(stderr, "-->kafkatcl_logging_eventProc\n");
 	kafkatcl_invoke_callback_with_argument (interp, kafkatcl_loggingCallbackObj, listObj);
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
-fprintf(stderr, "<--kafkatcl_logging_eventProc\n");
 	return 1;
 }
 
@@ -1307,7 +1300,6 @@ kafkatcl_stats_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_statsEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
-fprintf(stderr, "-->kafkatcl_stats_eventProc\n");
 
 	kafkatcl_statsEvent *evPtr = (kafkatcl_statsEvent *)tevPtr;
 	kafkatcl_objectClientData *ko = evPtr->ko;
@@ -1323,7 +1315,6 @@ fprintf(stderr, "-->kafkatcl_stats_eventProc\n");
 	free (evPtr->json);
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
-fprintf(stderr, "<--kafkatcl_stats_eventProc\n");
 	return 1;
 }
 
@@ -1347,7 +1338,6 @@ kafkatcl_error_eventProc (Tcl_Event *tevPtr, int flags) {
 	// our kafkatcl_errorEvent structure that has the Tcl_Event and
 	// some other stuff that we need.
 	// Go get that.
-fprintf(stderr, "-->kafkatcl_error_eventProc;\n");
 
 	kafkatcl_errorEvent *evPtr = (kafkatcl_errorEvent *)tevPtr;
 	kafkatcl_objectClientData *ko = evPtr->ko;
@@ -1389,8 +1379,7 @@ fprintf(stderr, "-->kafkatcl_error_eventProc;\n");
 	kafkatcl_invoke_callback_with_argument (interp, ko->errorCallbackObj, listObj);
 
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
-// it and don't want it removed from the queue
-fprintf(stderr, "<--kafkatcl_error_eventProc;\n");
+	// it and don't want it removed from the queue
 	return 1;
 }
 
@@ -1511,7 +1500,6 @@ int kafkatcl_stats_callback (rd_kafka_t *rk, char  *json, size_t jsonLen, void *
  */
 int
 kafkatcl_delivery_report_eventProc (Tcl_Event *tevPtr, int flags) {
-fprintf(stderr, "-->kafkatcl_delivery_report_eventProc;\n");
 
 	// we got called with a Tcl_Event pointer but really it's a pointer to
 	// our kafkatcl_statsEvent structure that has the Tcl_Event and
@@ -1540,7 +1528,6 @@ fprintf(stderr, "-->kafkatcl_delivery_report_eventProc;\n");
 
 	// tell the dispatcher we handled it.  0 would mean we didn't deal with
 	// it and don't want it removed from the queue
-fprintf(stderr, "<--kafkatcl_delivery_report_eventProc;\n");
 	return 1;
 }
 
@@ -2570,7 +2557,6 @@ kafkatcl_check_consumer_callbacks (kafkatcl_objectClientData *ko) {
 int
 kafkatcl_topicConsumerObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_topicConsumerObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_topicClientData *kt = (kafkatcl_topicClientData *)cData;
 	rd_kafka_topic_t *rkt = kt->rkt;
@@ -2850,7 +2836,6 @@ fprintf(stderr, "kafkatcl_topicConsumerObjectObjCmd\n");
 int
 kafkatcl_topicProducerObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_topicProducerObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_topicClientData *kt = (kafkatcl_topicClientData *)cData;
 	rd_kafka_topic_t *rkt = kt->rkt;
@@ -3105,7 +3090,6 @@ kafkatcl_createTopicObjectCommand (kafkatcl_handleClientData *kh, char *cmdName,
 int
 kafkatcl_queueObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_queueObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_queueClientData *kq = (kafkatcl_queueClientData *)cData;
 	rd_kafka_queue_t *rkqu = kq->rkqu;
@@ -3334,7 +3318,6 @@ kafkatcl_add_brokers (kafkatcl_handleClientData *kh, Tcl_Obj *brokers) {
 int
 kafkatcl_handleObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_handleObjectObjCmd\n");
     int         optIndex;
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)cData;
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
@@ -3781,8 +3764,7 @@ kafkatcl_set_subscriber_callback(Tcl_Interp *interp, kafkatcl_handleClientData *
 void
 kafkatcl_SubscriberEventCheckProc (ClientData clientData, int flags) {
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)clientData;
-fprintf(stderr, "-> kafkatcl_SubscriberEventCheckProc(clientData = 0x%8lx, flags=%d);\n", (long)clientData, flags);
-    assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
+	assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
 	rd_kafka_t *rk = kh->rk;
 	rd_kafka_message_t *message;
 	Tcl_Interp *interp = kh->interp;
@@ -3814,7 +3796,6 @@ fprintf(stderr, "-> kafkatcl_SubscriberEventCheckProc(clientData = 0x%8lx, flags
 
 	kh->inCallback = 0;
 
-fprintf(stderr, "<- kafkatcl_SubscriberEventCheckProc();\n");
 	// Stake undead callbacks.
 	Tcl_DecrRefCount(cb);
 }
@@ -3834,7 +3815,6 @@ fprintf(stderr, "<- kafkatcl_SubscriberEventCheckProc();\n");
 int
 kafkatcl_handleSubscriberObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_handleSubscriberObjectObjCmd\n");
 	int                        optIndex;
 	kafkatcl_handleClientData *kh = (kafkatcl_handleClientData *)cData;
     assert (kh->kafka_handle_magic == KAFKA_HANDLE_MAGIC);
@@ -4545,7 +4525,6 @@ kafkatcl_createSubscriberObjectCommand (kafkatcl_objectClientData *ko, char *cmd
 int
 kafkatcl_kafkaObjectObjCmd(ClientData cData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_kafkaObjectObjCmd\n");
 	int         optIndex;
 	kafkatcl_objectClientData *ko = (kafkatcl_objectClientData *)cData;
 	int resultCode = TCL_OK;
@@ -4898,13 +4877,10 @@ fprintf(stderr, "kafkatcl_kafkaObjectObjCmd\n");
 int
 kafkatcl_kafkaObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *CONST objv[])
 {
-fprintf(stderr, "kafkatcl_kafkaObjCmd\n");
     kafkatcl_objectClientData *ko;
     int                 optIndex;
     char               *cmdName;
     int                 autoGeneratedName;
-
-fprintf(stderr, "kafkatcl_kafkaObjCmd\n");
 
     static CONST char *options[] = {
         "create",

--- a/generic/kafkatcl.h
+++ b/generic/kafkatcl.h
@@ -118,6 +118,7 @@ typedef struct kafkatcl_handleClientData
 	Tcl_ThreadId threadId;
 	const struct rd_kafka_metadata *metadata;
 	Tcl_Obj *subscriberCallback;
+	int inCallback;
 } kafkatcl_handleClientData;
 
 typedef struct kafkatcl_topicClientData


### PR DESCRIPTION
* Remove subscribers and producers from Tcl event handlers when they're deleted.
* Don't allow deletion of subscriber inside a subscriber callback
- This may be fixable by using a shared Tcl event handler and our own queue that's smarter about handling deleted events.
* Add more asserts to catch stale clientData
- note, may need to use smart delayed cleanup because of already queued events.